### PR TITLE
Added recursion support

### DIFF
--- a/jobs/master/spec
+++ b/jobs/master/spec
@@ -22,3 +22,10 @@ properties:
   bind9.master.zones:
     description: "Map of DNS zone names to their BIND configuration file contents"
     default: {}
+
+  bind9.recursion.forwarders:
+    description: "List of DNS servers to forward recursive queries on to. If not specified, recursion is disabled"
+    default: []
+  bind9.recursion.allow_from:
+    description: "List of IPs or CIDRs to allow recursive queries from. If recursion is enabled, localhost and localnets will always be allowed"
+    default: []

--- a/jobs/master/templates/config/master.conf
+++ b/jobs/master/templates/config/master.conf
@@ -1,11 +1,32 @@
 # bind master configuration
 
+# allow only trusted nets/hosts to recurse
+acl trusted {
+  localhost;
+  localnets;
+<% properties.bind9.recursion.allow_from.to_a.each do |acl| %>
+  <%= acl %>;
+<% end %>
+};
+
 # sane defaults
 options {
   pid-file "/var/vcap/sys/run/master/master.pid";
   directory "/var/vcap/sys/run/master/data";
   version "nope";
+<% if properties.bind9.recursion.forwarders.to_a.length > 0 %>
+  recursion yes;
+  allow-recursion { trusted; };
+
+  forwarders {
+<% properties.bind9.recursion.forwarders.to_a.each do |svr| %>
+    <%= svr %>;
+<% end %>
+  };
+<% else %>
+  recursion no;
   allow-recursion { "none"; };
+<% end %>
 
   notify yes;
   also-notify    { <%= p('bind9.master.slaves', []).join('; ') %>; };

--- a/jobs/slave/spec
+++ b/jobs/slave/spec
@@ -18,3 +18,10 @@ properties:
   bind9.slave.allow_notify:
     description: "ACL (possible semi-colon delimited) to allow AXFR zone transfers from"
     default: "none"
+
+  bind9.recursion.forwarders:
+    description: "List of DNS servers to forward recursive queries on to. If not specified, recursion is disabled"
+    default: []
+  bind9.recursion.allow_from:
+    description: "List of IPs or CIDRs to allow recursive queries from. If recursion is enabled, localhost and localnets will always be allowed"
+    default: []

--- a/jobs/slave/templates/config/slave.conf
+++ b/jobs/slave/templates/config/slave.conf
@@ -1,13 +1,34 @@
 # bind slave configuration
 
+# allow only trusted nets/hosts to recurse
+acl trusted {
+  localhost;
+  localnets;
+<% properties.bind9.recursion.allow_from.to_a.each do |acl| %>
+  <%= acl %>;
+<% end %>
+};
+
 # sane defaults
 options {
   pid-file "/var/vcap/sys/run/slave/slave.pid";
   directory "/var/vcap/sys/run/slave";
   version "nope";
   allow-transfer { "none"; };
-  allow-recursion { "none"; };
   allow-notify { <%= p('bind9.slave.allow_notify') %>; };
+<% if properties.bind9.recursion.forwarders.to_a.length > 0 %>
+  recursion yes;
+  allow-recursion { trusted; };
+
+  forwarders {
+<% properties.bind9.recursion.forwarders.to_a.each do |svr| %>
+    <%= svr %>;
+<% end %>
+  };
+<% else %>
+  recursion no;
+  allow-recursion { "none"; };
+<% end %>
 };
 
 <% p('bind9.slave.zones', []).each do |zone| %>


### PR DESCRIPTION
Specifying `bind9.recursion.forwarders` will enable recursion,
and let you specify DNS servers to forward your recursive queries
on to. Recursion/forwarding is off by default.

`bind9.recursion.allow_from` is used to limit access on
responding to recursive queries. By default, only localhost +
localnets on the BOSH vm are allowed to perform recurive queries,
when it is enabled.
