### PR TITLE
Add support for zone type forward

### DIFF
--- a/jobs/master/spec
+++ b/jobs/master/spec
@@ -33,3 +33,7 @@ properties:
   bind9.options:
     description: "Map of additional options"
     default: {}
+
+  bind9.forward.zones:
+    description: "Forward zones in forward only mode,e.g. {name: zone1, forwarders: [1.1.1.1, 1.1.1.2]}"
+    default: {}

--- a/jobs/master/templates/config/master.conf
+++ b/jobs/master/templates/config/master.conf
@@ -45,4 +45,10 @@ zone "<%= domain %>" in {
 };
 <% end %>
 
+<% p('bind9.forward.zones').to_h.each do |domain, config| %>
+zone "<%= domain %>" in {
+  <%= config %>
+};
+<% end %>
+
 # vim:et:ft=named

--- a/jobs/master/templates/config/master.conf
+++ b/jobs/master/templates/config/master.conf
@@ -45,9 +45,15 @@ zone "<%= domain %>" in {
 };
 <% end %>
 
-<% p('bind9.forward.zones').to_h.each do |domain, config| %>
-zone "<%= domain %>" in {
-  <%= config %>
+<% p('bind9.forward.zones').each do |zone| %>
+zone "<%= zone['name'] %>" in {
+  type forward;
+  forward only;
+  forwarders {
+    <% (zone['forwarders'] || []).each do |srv| -%>
+      <%= srv %>;
+    <% end -%>
+  };
 };
 <% end %>
 

--- a/jobs/slave/spec
+++ b/jobs/slave/spec
@@ -29,3 +29,7 @@ properties:
   bind9.options:
     description: "Map of additional options"
     default: {}
+
+  bind9.forward.zones:
+    description: "Forward zones in forward only mode,e.g. {name: zone1, forwarders: [1.1.1.1, 1.1.1.2]}"
+    default: {}

--- a/jobs/slave/templates/config/slave.conf
+++ b/jobs/slave/templates/config/slave.conf
@@ -42,3 +42,9 @@ zone "<%= zone %>" {
   file "<%= zone %>.db";
 };
 <% end %>
+
+<% p('bind9.forward.zones').to_h.each do |domain, config| %>
+zone "<%= domain %>" in {
+  <%= config %>
+};
+<% end %>

--- a/jobs/slave/templates/config/slave.conf
+++ b/jobs/slave/templates/config/slave.conf
@@ -43,8 +43,14 @@ zone "<%= zone %>" {
 };
 <% end %>
 
-<% p('bind9.forward.zones').to_h.each do |domain, config| %>
-zone "<%= domain %>" in {
-  <%= config %>
+<% p('bind9.forward.zones').each do |zone| %>
+zone "<%= zone['name'] %>" in {
+  type forward;
+  forward only;
+  forwarders {
+    <% (zone['forwarders'] || []).each do |srv| -%>
+      <%= srv %>;
+    <% end -%>
+  };
 };
 <% end %>


### PR DESCRIPTION
Allow to add config for zone type forward.
My use case is to forward request to consul DNS in case of Vault in HA with consul backend, e.g.


>  forward:
>     zones:
>         service.consul: |
>             type forward;
>             forward only;
>             forwarders { 10.0.0.1; 10.0.0.2; 10.0.0.3; };

will generate

> zone "service.consul" in {
>   type forward;
>   forward only;
>   forwarders { 10.0.0.1; 10.0.0.2; 10.0.0.3; };
> };


Add  an entry DNS to `myvault.example.com IN CNAME active.vault.service.consul` will return the IP of active Vault node.
