### PR TITLE
Allow master to be overridden per zone

### DIFF
--- a/jobs/slave/spec
+++ b/jobs/slave/spec
@@ -14,7 +14,15 @@ properties:
   bind9.slave.master:
     description: "IP address of the master BIND9 nameserver"
   bind9.slave.zones:
-    description: "List of zones to transfer from the master"
+    description: "List of zones to transfer from the master with optional overrides for each zone. Currently only the master can be overridden per-zone"
+    example: |
+      slave:
+        zones:
+        #No overrides. Use defaults
+        - foo.com
+        #Override the master only
+        - bar.com:
+            master: 1.2.3.4
   bind9.slave.allow_notify:
     description: "ACL (possible semi-colon delimited) to allow AXFR zone transfers from"
     default: "none"

--- a/jobs/slave/templates/config/slave.conf
+++ b/jobs/slave/templates/config/slave.conf
@@ -35,11 +35,22 @@ options {
 <% end %>
 };
 
-<% p('bind9.slave.zones', []).each do |zone| %>
-zone "<%= zone %>" {
+<% p('bind9.slave.zones', []).each do |entry| %>
+<%
+  zone = {}
+  if entry.is_a?(Hash)
+    name, cfg = entry.first
+    zone['name'] = name
+    zone['master'] = cfg['master'] ? cfg['master'] : p('bind9.slave.master')
+  else
+    zone['name'] = entry
+    zone['master'] = p('bind9.slave.master')
+  end
+%>
+zone "<%= zone['name'] %>" {
   type slave;
-  masters { <%= p('bind9.slave.master') %>; };
-  file "<%= zone %>.db";
+  masters { <%= zone['master'] %>; };
+  file "<%= zone['name'] %>.db";
 };
 <% end %>
 


### PR DESCRIPTION
This PR enables basic overrides of which master server is used per-zone. Later, additional zone-specific values can be added to the zones and supported by updating the template (like ignoring the SOA retries time time, which servers could become a slave to this server, so on and soforth).

The structure of the properties was chosen to ensure that existing configs do not break.