### PR TITLE
Renamed options to bind_options so it matches the spec and master job

### DIFF
--- a/jobs/slave/spec
+++ b/jobs/slave/spec
@@ -23,6 +23,6 @@ properties:
     description: "List of IPs or CIDRs to allow recursive queries from. If recursion is enabled, localhost and localnets will always be allowed"
     default: []
 
-  options:
+  bind_options:
     description: "Map of additional options"
     default: {}


### PR DESCRIPTION
Hi,

I discovered that there appears to be an inconsistency in the spec file for the slave job. The spec file refers to the `options` parameter, but the template uses `bind_options`. The master job also uses `bind_options` throughout, so this quick rename just makes everything consistent.

Thanks!